### PR TITLE
Eslint-Watch polling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,5 @@ services:
       - NPM_CONFIG_PROGRESS=false
       - NPM_CONFIG_SPIN=false
       - MONGO_DB=test
+      - CHOKIDAR_USEPOLLING=true
     command: npm start

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cover": "istanbul cover --report lcovonly ./node_modules/.bin/_mocha -- -t 10000 -r test/support/env -R spec test/*.js test/**/*.js",
     "grunt:watch": "grunt watch",
     "lint": "eslint *.js lib/ models/ test/",
-    "lint:watch": "esw --watch *.js lib/ models/ test/",
+    "lint:watch": "esw --color --watch *.js lib/ models/ test/",
     "nsp": "nsp check",
     "semantic-release": "semantic-release",
     "start": "supervisor -w index.js,lib -e js index.js",


### PR DESCRIPTION
Enable polling on Eslint-Watch to work inside of Docker containers.

Related: rizowski/eslint-watch#92