### PR TITLE
Fix/standardize log response

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ router.get('/steder/:sted/logg', (req, res, next) => {
     .where('ntb_steder_id').equals(req.params.sted)
     .limit(50)
     .sort({ timestamp: -1 })
-    .select('-dnt_user_id -location')
+    .then(checkins => checkins.map(c => c.anonymize(req.headers['x-user-id'])))
     .then(data => res.json({ data }))
     .catch(error => next(new HttpError('Database failure', 500, error)));
 });

--- a/test/acceptance/checkin.js
+++ b/test/acceptance/checkin.js
@@ -203,8 +203,10 @@ describe('GET /steder/:sted/logg', () => {
     JSON.parse(JSON.stringify(checkins[1])),
     JSON.parse(JSON.stringify(checkins[2])),
   ].map(c => {
-    delete c.dnt_user_id;
-    delete c.location;
+    if (c.public === false) {
+      delete c.dnt_user_id;
+      delete c.location;
+    }
     return c;
   });
 


### PR DESCRIPTION
Checkin log now returns user id and location if not public or checkin is associated to user requesting log.

Closes #37 