### PR TITLE
Fix/timestamp validation

### DIFF
--- a/models/Checkin.js
+++ b/models/Checkin.js
@@ -73,14 +73,14 @@ checkinSchema.path('location.coordinates').validate(function validateCoordinates
     .then(res => res.json())
     .then(sted => {
       const distance = geoutil.pointDistance(value, sted.geojson.coordinates, true);
-      cb(distance <= process.env.CHECKIN_MAX_DISTANCE);
+      cb(distance <= parseInt(process.env.CHECKIN_MAX_DISTANCE, 10));
     });
 }, `Checkin only within ${process.env.CHECKIN_MAX_DISTANCE} m. radius`);
 
 checkinSchema.path('timestamp').validate(function validateTimestamp(value, cb) {
   const Checkin = mongoose.model('Checkin', checkinSchema);
   const checkinQuarantine = new Date(value);
-  checkinQuarantine.setSeconds(checkinQuarantine.getSeconds() - process.env.CHECKIN_TIMEOUT);
+  checkinQuarantine.setSeconds(checkinQuarantine.getSeconds() - parseInt(process.env.CHECKIN_TIMEOUT, 10));
 
   Checkin.find()
     .where('dnt_user_id')

--- a/models/Checkin.js
+++ b/models/Checkin.js
@@ -51,11 +51,11 @@ checkinSchema.methods.anonymize = function anonymize(userId) {
   return this;
 };
 
-checkinSchema.path('timestamp').validate(function validateTimestamp(value, cb) {
+checkinSchema.path('timestamp').validate(function validateTimestamp(value, cb) { // eslint-disable-line prefer-arrow-callback
   cb(new Date(value) < new Date());
 }, `Checkins from the future (timestamp greater than ${new Date().toISOString()}) not allowed`);
 
-checkinSchema.path('location.coordinates').validate(function validateCoordinates(value, cb) {
+checkinSchema.path('location.coordinates').validate(function validateCoordinates(value, cb) { // eslint-disable-line prefer-arrow-callback
   const env = process.env.NTB_API_ENV || 'api';
   const key = process.env.NTB_API_KEY;
 
@@ -77,10 +77,12 @@ checkinSchema.path('location.coordinates').validate(function validateCoordinates
     });
 }, `Checkin only within ${process.env.CHECKIN_MAX_DISTANCE} m. radius`);
 
-checkinSchema.path('timestamp').validate(function validateTimestamp(value, cb) {
+checkinSchema.path('timestamp').validate(function validateTimestamp(value, cb) { // eslint-disable-line prefer-arrow-callback
   const Checkin = mongoose.model('Checkin', checkinSchema);
   const checkinQuarantine = new Date(value);
-  checkinQuarantine.setSeconds(checkinQuarantine.getSeconds() - parseInt(process.env.CHECKIN_TIMEOUT, 10));
+  checkinQuarantine.setSeconds(
+    checkinQuarantine.getSeconds() - parseInt(process.env.CHECKIN_TIMEOUT, 10)
+  );
 
   Checkin.find()
     .where('dnt_user_id')

--- a/models/Checkin.js
+++ b/models/Checkin.js
@@ -51,6 +51,10 @@ checkinSchema.methods.anonymize = function anonymize(userId) {
   return this;
 };
 
+checkinSchema.path('timestamp').validate(function validateTimestamp(value, cb) {
+  cb(new Date(value) < new Date());
+}, `Checkins from the future (timestamp greater than ${new Date().toISOString()}) not allowed`);
+
 checkinSchema.path('location.coordinates').validate(function validateCoordinates(value, cb) {
   const env = process.env.NTB_API_ENV || 'api';
   const key = process.env.NTB_API_KEY;
@@ -74,11 +78,6 @@ checkinSchema.path('location.coordinates').validate(function validateCoordinates
 }, `Checkin only within ${process.env.CHECKIN_MAX_DISTANCE} m. radius`);
 
 checkinSchema.path('timestamp').validate(function validateTimestamp(value, cb) {
-  // Check for checkins from the future
-  if (new Date(value) > new Date()) {
-    cb(false);
-  }
-
   const Checkin = mongoose.model('Checkin', checkinSchema);
   const checkinQuarantine = new Date(value);
   checkinQuarantine.setSeconds(checkinQuarantine.getSeconds() - process.env.CHECKIN_TIMEOUT);

--- a/models/Checkin.js
+++ b/models/Checkin.js
@@ -85,6 +85,8 @@ checkinSchema.path('timestamp').validate(function validateTimestamp(value, cb) {
   Checkin.find()
     .where('dnt_user_id')
     .equals(this.dnt_user_id)
+    .where('ntb_steder_id')
+    .equals(this.ntb_steder_id)
     .where('timestamp')
     .gt(checkinQuarantine)
     .exec((err, result) => {

--- a/test/acceptance/checkin.js
+++ b/test/acceptance/checkin.js
@@ -104,7 +104,12 @@ describe('POST /steder/:sted/besok', () => {
 
   it('returns error for second checkin before checkin timeout', () => {
     const checkinDataBeforeTimeout = JSON.parse(JSON.stringify(checkinData));
-    checkinDataBeforeTimeout.timestamp = '2016-07-07T23:59:59.923Z';
+    const checkinTimestamp = new Date(checkins[0].timestamp);
+    const invalidCheckinTimestamp = new Date(checkinTimestamp.setSeconds(
+      checkinTimestamp.getSeconds() + parseInt(process.env.CHECKIN_TIMEOUT, 10) - 1
+    ));
+    checkinDataBeforeTimeout.timestamp = invalidCheckinTimestamp.toISOString();
+
     return appMocked.post(url)
       .set('X-User-Id', '1234')
       .set('X-User-Token', 'abc123')

--- a/test/acceptance/checkin.js
+++ b/test/acceptance/checkin.js
@@ -85,6 +85,23 @@ describe('POST /steder/:sted/besok', () => {
       })
   ));
 
+  it('returns error for checkins from the future', () => {
+    const checkinDataBeforeTimeout = JSON.parse(JSON.stringify(checkinData));
+    const now = new Date();
+    checkinDataBeforeTimeout.timestamp = now.setHours(now.getHours() + 24);
+    return appMocked.post(url)
+      .set('X-User-Id', '1234')
+      .set('X-User-Token', 'abc123')
+      .send(checkinDataBeforeTimeout)
+      .expect(400)
+      .expect(res => {
+        assert.equal(typeof res.body.errors.timestamp, 'object');
+        assert.equal(/from the future/.test(res.body.errors.timestamp.message), true);
+        assert.equal(res.body.code, 400);
+        assert.equal(res.body.message, 'Checkin validation failed');
+      });
+  });
+
   it('returns error for second checkin before checkin timeout', () => {
     const checkinDataBeforeTimeout = JSON.parse(JSON.stringify(checkinData));
     checkinDataBeforeTimeout.timestamp = '2016-07-07T23:59:59.923Z';

--- a/test/acceptance/checkin.js
+++ b/test/acceptance/checkin.js
@@ -106,7 +106,7 @@ describe('POST /steder/:sted/besok', () => {
     const checkinDataBeforeTimeout = JSON.parse(JSON.stringify(checkinData));
     const checkinTimestamp = new Date(checkins[0].timestamp);
     const invalidCheckinTimestamp = new Date(checkinTimestamp.setSeconds(
-      checkinTimestamp.getSeconds() + parseInt(process.env.CHECKIN_TIMEOUT, 10) - 1
+      checkinTimestamp.getSeconds() + parseInt(process.env.CHECKIN_TIMEOUT, 10) - 1 // eslint-disable-line no-mixed-operators, max-len
     ));
     checkinDataBeforeTimeout.timestamp = invalidCheckinTimestamp.toISOString();
 

--- a/test/fixtures/checkins.js
+++ b/test/fixtures/checkins.js
@@ -4,21 +4,21 @@ const objectId = require('mongoose').Types.ObjectId;
 
 module.exports = [{
   _id: objectId('200000000000000000000000'),
-  timestamp: new Date('2016-07-07T23:32:49.923Z'),
+  timestamp: new Date('2016-07-07T20:32:49.923Z'),
   location: { type: 'Point', coordinates: [-117.220406, 32.719464] },
   public: false,
   ntb_steder_id: objectId('400000000000000000000000'),
   dnt_user_id: 1234,
 }, {
   _id: objectId('200000000000000000000001'),
-  timestamp: new Date('2016-07-07T23:32:50.923Z'),
+  timestamp: new Date('2016-07-07T20:32:50.923Z'),
   location: { type: 'Point', coordinates: [-117.220406, 32.719464] },
   public: true,
   ntb_steder_id: objectId('400000000000000000000001'),
   dnt_user_id: 1234,
 }, {
   _id: objectId('200000000000000000000002'),
-  timestamp: new Date('2016-07-06T23:32:58.923Z'),
+  timestamp: new Date('2016-07-06T20:32:58.923Z'),
   location: { type: 'Point', coordinates: [-117.220406, 32.719464] },
   public: false,
   ntb_steder_id: objectId('400000000000000000000001'),

--- a/test/models/Checkin.js
+++ b/test/models/Checkin.js
@@ -3,6 +3,7 @@
 
 const assert = require('assert');
 const mockery = require('mockery');
+const checkins = require('../fixtures/checkins.js');
 
 describe('Checkin', () => {
   describe('#getCheckinsForList()', () => {
@@ -88,11 +89,15 @@ describe('Checkin', () => {
     });
 
     it('rejects a second checkin before checkin timeout', done => {
+      const checkinTimestamp = new Date(checkins[0].timestamp);
+      const invalidCheckinTimestamp = new Date(checkinTimestamp.setSeconds(
+        checkinTimestamp.getSeconds() + parseInt(process.env.CHECKIN_TIMEOUT, 10) - 1
+      ));
       const checkinData = {
         dnt_user_id: 1234,
         ntb_steder_id: '400000000000000000000000',
-        timestamp: '2016-07-07T23:50:50.923Z',
         location: { coordinates: [8.312466144561768, 61.63644183145977] },
+        timestamp: invalidCheckinTimestamp.toISOString()
       };
       const checkin = new Checkin(checkinData);
 

--- a/test/models/Checkin.js
+++ b/test/models/Checkin.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert');
 const mockery = require('mockery');
-const checkins = require('../fixtures/checkins.js');
+const checkinsFixtures = require('../fixtures/checkins.js');
 
 describe('Checkin', () => {
   describe('#getCheckinsForList()', () => {
@@ -89,15 +89,15 @@ describe('Checkin', () => {
     });
 
     it('rejects a second checkin before checkin timeout', done => {
-      const checkinTimestamp = new Date(checkins[0].timestamp);
+      const checkinTimestamp = new Date(checkinsFixtures[0].timestamp);
       const invalidCheckinTimestamp = new Date(checkinTimestamp.setSeconds(
-        checkinTimestamp.getSeconds() + parseInt(process.env.CHECKIN_TIMEOUT, 10) - 1
+        checkinTimestamp.getSeconds() + parseInt(process.env.CHECKIN_TIMEOUT, 10) - 1 // eslint-disable-line no-mixed-operators, max-len
       ));
       const checkinData = {
         dnt_user_id: 1234,
         ntb_steder_id: '400000000000000000000000',
         location: { coordinates: [8.312466144561768, 61.63644183145977] },
-        timestamp: invalidCheckinTimestamp.toISOString()
+        timestamp: invalidCheckinTimestamp.toISOString(),
       };
       const checkin = new Checkin(checkinData);
 


### PR DESCRIPTION
* [x] separate timestamp future checkin validations into own validation rule
* [x] use parseInt to fix potential bugs when calculating wether checkins are valid, based on env vars
* [x] allow user to check in to other places while waiting for timeout